### PR TITLE
New request flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.vscode
 **/node_modules
 web-ext-artifacts

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-extension",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "main": "index.js",
   "license": "MIT",
   "private": true,

--- a/src/background.js
+++ b/src/background.js
@@ -13,6 +13,11 @@ RUNTIME.runtime.onMessageExternal.addListener(
         case "credentials":
           const credentials = await retrieveSpotifyCookies();
           sendResponse({ credentials: credentials });
+          if (credentials) {
+            // Log out the user from Spotify
+            // to prevent cookies from getting invalidated
+            await removeAllCookies(SPOTIFY_DOMAIN);
+          }
           return true; // Keep the message channel open for the asynchronous response
       }
     }

--- a/src/background.js
+++ b/src/background.js
@@ -4,39 +4,27 @@ const SPOTIFY_DOMAIN = "https://podcasters.spotify.com";
 // Register handler for external communication (new flow)
 RUNTIME.runtime.onMessageExternal.addListener(
   async (request, sender, sendResponse) => {
-    try {
-      if (request?.message) {
-        switch (request.message) {
-          case "version":
-            const manifest = RUNTIME.runtime.getManifest();
-            sendResponse({ version: manifest.version });
-            break;
-          case "credentials":
-            const credentials = await retrieveSpotifyCookies();
-            sendResponse({ credentials });
-            return true; // Keep the message channel open for the asynchronous response
-        }
+    if (request?.message) {
+      switch (request.message) {
+        case "version":
+          const manifest = RUNTIME.runtime.getManifest();
+          sendResponse({ version: manifest.version });
+          break;
+        case "credentials":
+          const credentials = await retrieveSpotifyCookies();
+          sendResponse({ credentials: credentials ?? {} }); // Return empty object if no credentials
+          return true; // Keep the message channel open for the asynchronous response
       }
-    } catch (error) {
-      console.error("Error processing request:", error);
-      sendResponse({ error: "Failed to process request" });
     }
   }
 );
 
 // Register handler for communication with content script (old flow)
 RUNTIME.runtime.onMessage.addListener(async (request, sender, sendResponse) => {
-  try {
-    if (request.type === "spotifycookies") {
-      const spotifyCredentials = await retrieveSpotifyCookies();
-      sendResponse({ response: spotifyCredentials });
-      if (spotifyCredentials) {
-        await removeAllCookies(SPOTIFY_DOMAIN);
-      }
-      return true; // Indicates that we will respond asynchronously
-    }
-  } catch (error) {
-    sendResponse({ error: "Failed to retrieve credentials" });
+  if (request.type === "spotifycookies") {
+    const spotifyCredentials = await retrieveSpotifyCookies();
+    sendResponse({ response: spotifyCredentials ?? {} }); // Return empty object if no credentials
+    return true; // Indicates that we will respond asynchronously
   }
 });
 
@@ -45,16 +33,11 @@ const getDomainCookies = async (domain) => {
   return RUNTIME.cookies.getAll({ url: domain });
 };
 
-// Remove a specific cookie
-const removeCookie = async (cookie) => {
-  await RUNTIME.cookies.remove(cookie);
-};
-
 // Remove all cookies for a specified domain
 const removeAllCookies = async (domain) => {
   const cookies = await getDomainCookies(domain);
   for (let cookie of cookies) {
-    await removeCookie({
+    await RUNTIME.cookies.remove({
       url: domain,
       name: cookie.name,
     });
@@ -66,14 +49,11 @@ const retrieveSpotifyCookies = async () => {
   const cookies = await getDomainCookies(SPOTIFY_DOMAIN);
   const spotifyCredentials = cookies
     .filter((cookie) => ["sp_key", "sp_dc", "anchorpw_s"].includes(cookie.name))
-    .reduce((result, cookie) => {
-      result[cookie.name] = cookie.value;
-      return result;
+    .reduce((acc, cookie) => {
+      acc[cookie.name] = cookie.value;
+      return acc;
     }, {});
 
-  return spotifyCredentials.sp_key ||
-    spotifyCredentials.sp_dc ||
-    spotifyCredentials.anchorpw_s
-    ? spotifyCredentials
-    : null;
+  // If no specific credentials are found, it's not an error.
+  return Object.keys(spotifyCredentials).length ? spotifyCredentials : null;
 };

--- a/src/background.js
+++ b/src/background.js
@@ -1,93 +1,79 @@
 const RUNTIME = chrome || window.browser;
 const SPOTIFY_DOMAIN = "https://podcasters.spotify.com";
 
-// register handler for external communication (new flow)
-RUNTIME.runtime.onMessageExternal.addListener(function (
-  request,
-  sender,
-  sendResponse
-) {
-  if (request) {
-    if (request.message) {
-      if (request.message == "version") {
-        // Retrieve the extension version
-        const manifest = chrome.runtime.getManifest();
-        sendResponse({ version: manifest.version });
-      } else if (request.message == "credentials") {
-        retrieveSpotifyCookies()
-          .then((credentials) => {
-            sendResponse({ credentials: credentials });
-          })
-          .catch((error) => {
-            console.error("Error retrieving Spotify credentials:", error);
-            sendResponse({ error: "Failed to retrieve credentials" });
-          });
-        return true; // keep the message channel open for the asynchronous response
+// Register handler for external communication (new flow)
+RUNTIME.runtime.onMessageExternal.addListener(
+  async (request, sender, sendResponse) => {
+    try {
+      if (request?.message) {
+        switch (request.message) {
+          case "version":
+            const manifest = RUNTIME.runtime.getManifest();
+            sendResponse({ version: manifest.version });
+            break;
+          case "credentials":
+            const credentials = await retrieveSpotifyCookies();
+            sendResponse({ credentials });
+            return true; // Keep the message channel open for the asynchronous response
+        }
       }
+    } catch (error) {
+      console.error("Error processing request:", error);
+      sendResponse({ error: "Failed to process request" });
     }
   }
-});
+);
 
-// register handler for communication with content script (old flow)
-RUNTIME.runtime.onMessage.addListener((request, sender, sendResponse) => {
-  if (request.type && request.type === "spotifycookies") {
-    retrieveSpotifyCookies()
-      .then((spotifyCredentials) => {
-        sendResponse({ response: spotifyCredentials });
-        if (spotifyCredentials !== null) {
-          removeAllCookies(SPOTIFY_DOMAIN);
-        }
-      })
-      .catch((error) => {
-        console.error("Error retrieving Spotify credentials:", error);
-        sendResponse({ error: "Failed to retrieve credentials" });
-      });
-    return true; // Indicates that we will respond asynchronously
+// Register handler for communication with content script (old flow)
+RUNTIME.runtime.onMessage.addListener(async (request, sender, sendResponse) => {
+  try {
+    if (request.type === "spotifycookies") {
+      const spotifyCredentials = await retrieveSpotifyCookies();
+      sendResponse({ response: spotifyCredentials });
+      if (spotifyCredentials) {
+        await removeAllCookies(SPOTIFY_DOMAIN);
+      }
+      return true; // Indicates that we will respond asynchronously
+    }
+  } catch (error) {
+    sendResponse({ error: "Failed to retrieve credentials" });
   }
 });
 
-// return all cookies for a specified domain (which is allowed in manifest.json)
+// Return all cookies for a specified domain
 const getDomainCookies = async (domain) => {
-  return await RUNTIME.cookies.getAll({ url: domain });
+  return RUNTIME.cookies.getAll({ url: domain });
 };
 
-// remove a specific cookie
+// Remove a specific cookie
 const removeCookie = async (cookie) => {
   await RUNTIME.cookies.remove(cookie);
 };
 
-// remove all cookies for a specified domain
+// Remove all cookies for a specified domain
 const removeAllCookies = async (domain) => {
   const cookies = await getDomainCookies(domain);
-  cookies.forEach((cookie) => {
-    removeCookie({
+  for (let cookie of cookies) {
+    await removeCookie({
       url: domain,
       name: cookie.name,
     });
-  });
+  }
 };
 
-// retrieve Spotify cookies
+// Retrieve Spotify cookies
 const retrieveSpotifyCookies = async () => {
-  return getDomainCookies(SPOTIFY_DOMAIN).then((cookies) => {
-    const spotifyCredentials = cookies
-      .filter((cookie) =>
-        ["sp_key", "sp_dc", "anchorpw_s"].includes(cookie.name)
-      )
-      .reduce((result, cookie) => {
-        result[cookie.name] = cookie.value;
-        return result;
-      }, {});
+  const cookies = await getDomainCookies(SPOTIFY_DOMAIN);
+  const spotifyCredentials = cookies
+    .filter((cookie) => ["sp_key", "sp_dc", "anchorpw_s"].includes(cookie.name))
+    .reduce((result, cookie) => {
+      result[cookie.name] = cookie.value;
+      return result;
+    }, {});
 
-    if (
-      spotifyCredentials.sp_key ||
-      spotifyCredentials.sp_dc ||
-      spotifyCredentials.anchorpw_s
-    ) {
-      return spotifyCredentials;
-    } else {
-      // No valid credentials found yet (which is not an error)
-      return null;
-    }
-  });
+  return spotifyCredentials.sp_key ||
+    spotifyCredentials.sp_dc ||
+    spotifyCredentials.anchorpw_s
+    ? spotifyCredentials
+    : null;
 };

--- a/src/background.js
+++ b/src/background.js
@@ -12,7 +12,7 @@ RUNTIME.runtime.onMessageExternal.addListener(
           break;
         case "credentials":
           const credentials = await retrieveSpotifyCookies();
-          sendResponse({ credentials: credentials ?? {} }); // Return empty object if no credentials
+          sendResponse({ credentials: credentials });
           return true; // Keep the message channel open for the asynchronous response
       }
     }
@@ -55,5 +55,6 @@ const retrieveSpotifyCookies = async () => {
     }, {});
 
   // If no specific credentials are found, it's not an error.
+  // Just return `null` to indicate that no credentials are found.
   return Object.keys(spotifyCredentials).length ? spotifyCredentials : null;
 };

--- a/src/background.js
+++ b/src/background.js
@@ -1,29 +1,93 @@
-const runtime = chrome || window.browser
+const RUNTIME = chrome || window.browser;
+const SPOTIFY_DOMAIN = "https://podcasters.spotify.com";
 
-// register handler for communication with content script
-runtime.runtime.onMessage.addListener((request, sender, sendResponse) => {
-
-  const runtime = chrome || window.browser
-
-  // return all cookies for a specified domain (which is allowed in manifest.json)
-  const getDomainCookies = async (domain) => {
-    const cookies = await runtime.cookies.getAll({ url: domain })
-    return cookies
+// register handler for external communication (new flow)
+RUNTIME.runtime.onMessageExternal.addListener(function (
+  request,
+  sender,
+  sendResponse
+) {
+  if (request) {
+    if (request.message) {
+      if (request.message == "version") {
+        // Retrieve the extension version
+        const manifest = chrome.runtime.getManifest();
+        sendResponse({ version: manifest.version });
+      } else if (request.message == "credentials") {
+        retrieveSpotifyCookies()
+          .then((credentials) => {
+            sendResponse({ credentials: credentials });
+          })
+          .catch((error) => {
+            console.error("Error retrieving Spotify credentials:", error);
+            sendResponse({ error: "Failed to retrieve credentials" });
+          });
+        return true; // keep the message channel open for the asynchronous response
+      }
+    }
   }
+});
 
-  // remove a specific cookie
-  const removeCookie = async (details) => {
-    await runtime.cookies.remove(details)
-  }
-
+// register handler for communication with content script (old flow)
+RUNTIME.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.type && request.type === "spotifycookies") {
-    getDomainCookies("https://podcasters.spotify.com").then((cookies) => {
-      sendResponse({ response: cookies })
-
-      cookies.forEach(cookie => {
-        removeCookie({ url: "https://podcasters.spotify.com", name: cookie.name })
+    retrieveSpotifyCookies()
+      .then((spotifyCredentials) => {
+        sendResponse({ response: spotifyCredentials });
+        if (spotifyCredentials !== null) {
+          removeAllCookies(SPOTIFY_DOMAIN);
+        }
       })
-    })
+      .catch((error) => {
+        console.error("Error retrieving Spotify credentials:", error);
+        sendResponse({ error: "Failed to retrieve credentials" });
+      });
+    return true; // Indicates that we will respond asynchronously
   }
-  return true
-})
+});
+
+// return all cookies for a specified domain (which is allowed in manifest.json)
+const getDomainCookies = async (domain) => {
+  return await RUNTIME.cookies.getAll({ url: domain });
+};
+
+// remove a specific cookie
+const removeCookie = async (cookie) => {
+  await RUNTIME.cookies.remove(cookie);
+};
+
+// remove all cookies for a specified domain
+const removeAllCookies = async (domain) => {
+  const cookies = await getDomainCookies(domain);
+  cookies.forEach((cookie) => {
+    removeCookie({
+      url: domain,
+      name: cookie.name,
+    });
+  });
+};
+
+// retrieve Spotify cookies
+const retrieveSpotifyCookies = async () => {
+  return getDomainCookies(SPOTIFY_DOMAIN).then((cookies) => {
+    const spotifyCredentials = cookies
+      .filter((cookie) =>
+        ["sp_key", "sp_dc", "anchorpw_s"].includes(cookie.name)
+      )
+      .reduce((result, cookie) => {
+        result[cookie.name] = cookie.value;
+        return result;
+      }, {});
+
+    if (
+      spotifyCredentials.sp_key ||
+      spotifyCredentials.sp_dc ||
+      spotifyCredentials.anchorpw_s
+    ) {
+      return spotifyCredentials;
+    } else {
+      // No valid credentials found yet (which is not an error)
+      return null;
+    }
+  });
+};

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "OpenPodcast Extension",
-  "version": "1.3",
+  "version": "1.4",
   "description": "Shows Spotify keys on openpodcast.dev to connect a Podcasters Dashboard with Open Podcast Analytics",
   "background": {
     "service_worker": "background.js"
@@ -16,12 +16,20 @@
     {
       "matches": [
         "*://*.openpodcast.dev/*",
-        "*://*.openpodcast.app/*"
+        "*://*.openpodcast.app/*",
+        "*://localhost:*/*"
       ],
       "js": [
         "openpodcast.js"
       ],
-      "run_at": "document_end"
+      "run_at": "document_idle"
     }
-  ]
+  ],
+  "externally_connectable": {
+    "matches": [
+      "*://*.openpodcast.dev/*",
+      "*://*.openpodcast.app/*",
+      "*://localhost:*/*"
+    ]
+  }
 }

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -1,6 +1,6 @@
 {
   "name": "OpenPodcast Extension",
-  "version": "1.3",
+  "version": "1.4",
   "description": "Shows Spotify keys on openpodcast.dev to connect a Podcasters Dashboard with Open Podcast Analytics",
   "background": {
     "scripts": [
@@ -16,12 +16,20 @@
     {
       "matches": [
         "*://*.openpodcast.dev/*",
-        "*://*.openpodcast.app/*"
+        "*://*.openpodcast.app/*",
+        "*://localhost:*/*"
       ],
       "js": [
         "openpodcast.js"
       ],
-      "run_at": "document_end"
+      "run_at": "document_idle"
     }
-  ]
+  ],
+  "externally_connectable": {
+    "matches": [
+      "*://*.openpodcast.dev/*",
+      "*://*.openpodcast.app/*",
+      "*://localhost:*/*"
+    ]
+  }
 }

--- a/src/openpodcast.js
+++ b/src/openpodcast.js
@@ -1,4 +1,4 @@
-const runtime = window.browser || chrome;
+const RUNTIME = window.browser || chrome;
 
 const email = "echo@openpodcast.dev";
 let lastMessage = "";
@@ -18,21 +18,25 @@ function createEmailSendButton(email, subject, body) {
   return button;
 }
 
-//insert html at the beginning of the website
-function showCredentialsOnWebsite(creds) {
+// Insert HTML at the beginning of the website
+//
+// The new flow does not require this function anymore, because it fetches the
+// credentials with a message to the background.js, but the old flow is still
+// here for backwards compatibility.
+function showCredentialsOnWebsite(credentials) {
   let message = `No Spotify credentials found, are you logged in on <a href="https://podcasters.spotify.com" target="_blank">podcasters.spotify.com</a>? (Maybe reload this page.)`;
-  if (creds.sp_key && creds.sp_dc) {
-    message = `Spotify Data: key: ${creds["sp_key"]}, dc: ${creds["sp_dc"]} END`;
+  if (credentials.sp_key && credentials.sp_dc) {
+    message = `Spotify Data: key: ${credentials["sp_key"]}, dc: ${credentials["sp_dc"]} END`;
   }
-  if (creds.anchorpw_s) {
-    message = `Anchor Data: anchorpw_s: ${creds["anchorpw_s"]} END`;
+  if (credentials.anchorpw_s) {
+    message = `Anchor Data: anchorpw_s: ${credentials["anchorpw_s"]} END`;
   }
 
   // create div
   const div = document.createElement("div");
 
-  // if any creds set, show email button to send credentials to OpenPodcast team
-  if (creds.sp_key || creds.sp_dc || creds.anchorpw_s) {
+  // if any credentials set, show email button to send credentials to OpenPodcast team
+  if (credentials.sp_key || credentials.sp_dc || credentials.anchorpw_s) {
     const button = createEmailSendButton(
       email,
       "OpenPodcast Spotify Credentials",
@@ -49,6 +53,12 @@ function showCredentialsOnWebsite(creds) {
   div.appendChild(p);
 
   const parentElement = document.getElementById("openpodcast-plugin");
+
+  if (!parentElement) {
+    // Do nothing if the parent element is not found
+    return;
+  }
+
   // remove all children and set new content
   while (parentElement.firstChild) {
     parentElement.removeChild(parentElement.firstChild);
@@ -60,45 +70,30 @@ function showCredentialsOnWebsite(creds) {
 // is allowed to do this)
 async function retrieveSpotifyCookies() {
   // sends a message to the background.js and retrieve cookies
-  const message = await chrome.runtime.sendMessage({ type: "spotifycookies" });
-
-  const cookies = message.response;
-  const spotifyCreds = cookies
-    //filter for cookies we need and map to a simple lookupobject
-    .filter(
-      (cookie) =>
-        cookie.name === "sp_key" ||
-        cookie.name === "sp_dc" ||
-        cookie.name === "anchorpw_s"
-    )
-    .reduce((result, cookie) => {
-      result[cookie.name] = cookie.value;
-      return result;
-    }, {});
-
-  return spotifyCreds;
+  const message = await RUNTIME.runtime.sendMessage({ type: "spotifycookies" });
+  // Credentials are returned in the response (and already validated)
+  // This returns `null` if no credentials are found
+  return message.response;
 }
 
-// check if current website is the OpenPodcast website where we want to show the credentials
-function isOnOpenPodcastWebsite() {
-  return (
-    window.location.href.match(/https:\/\/openpodcast.dev\/.*connect/) &&
-    document.getElementById("openpodcast-plugin")
-  );
+// Check if current website is the Open Podcast website where we want to show the
+// credentials. This is only used on openpodcast.dev
+function isOnOpenPodcastDevWebsite() {
+  const res =
+    /^(https?:\/\/)?(www\.)?(openpodcast\.dev|localhost)/.test(
+      window.location.href
+    ) && document.getElementById("openpodcast-plugin") !== null;
+  return res;
 }
 
 // Function to initiate the loop
 function checkForCredentials() {
   checkLoopTimer = setInterval(async () => {
-    if (isOnOpenPodcastWebsite()) {
-      const spotifyCreds = await retrieveSpotifyCookies();
+    if (isOnOpenPodcastDevWebsite()) {
+      const spotifyCredentials = await retrieveSpotifyCookies();
 
-      // Check if the retrieved credentials are valid
-      if (
-        spotifyCreds &&
-        (spotifyCreds.sp_key || spotifyCreds.sp_dc || spotifyCreds.anchorpw_s)
-      ) {
-        showCredentialsOnWebsite(spotifyCreds);
+      if (spotifyCredentials) {
+        showCredentialsOnWebsite(spotifyCredentials);
 
         // Clear the timer interval since the credentials have been retrieved
         // This will stop the loop

--- a/src/openpodcast.js
+++ b/src/openpodcast.js
@@ -1,19 +1,15 @@
 const RUNTIME = window.browser || chrome;
-
 const email = "echo@openpodcast.dev";
-let lastMessage = "";
-
-// Store the ID of the interval, which we can later use to clear
-let checkLoopTimer;
+let checkInProgress = false;
 
 function createEmailSendButton(email, subject, body) {
   const button = document.createElement("button");
   button.innerHTML =
     "Click here to send credentials to OpenPodcast Team (via Email)";
   button.onclick = () => {
-    window.location.href = `mailto:${email}?subject=${subject}&body=${encodeURIComponent(
-      body
-    )}`;
+    window.location.href = `mailto:${email}?subject=${encodeURIComponent(
+      subject
+    )}&body=${encodeURIComponent(body)}`;
   };
   return button;
 }
@@ -26,16 +22,13 @@ function createEmailSendButton(email, subject, body) {
 function showCredentialsOnWebsite(credentials) {
   let message = `No Spotify credentials found, are you logged in on <a href="https://podcasters.spotify.com" target="_blank">podcasters.spotify.com</a>? (Maybe reload this page.)`;
   if (credentials.sp_key && credentials.sp_dc) {
-    message = `Spotify Data: key: ${credentials["sp_key"]}, dc: ${credentials["sp_dc"]} END`;
+    message = `Spotify Data: key: ${credentials.sp_key}, dc: ${credentials.sp_dc} END`;
   }
   if (credentials.anchorpw_s) {
-    message = `Anchor Data: anchorpw_s: ${credentials["anchorpw_s"]} END`;
+    message = `Anchor Data: anchorpw_s: ${credentials.anchorpw_s} END`;
   }
 
-  // create div
   const div = document.createElement("div");
-
-  // if any credentials set, show email button to send credentials to OpenPodcast team
   if (credentials.sp_key || credentials.sp_dc || credentials.anchorpw_s) {
     const button = createEmailSendButton(
       email,
@@ -43,61 +36,62 @@ function showCredentialsOnWebsite(credentials) {
       message
     );
     button.style.marginBottom = "2em";
-    button.style.display = "block";
     div.appendChild(button);
   }
 
-  // show message
   const p = document.createElement("p");
   p.innerHTML = message;
   div.appendChild(p);
 
   const parentElement = document.getElementById("openpodcast-plugin");
-
-  if (!parentElement) {
-    // Do nothing if the parent element is not found
-    return;
+  if (parentElement) {
+    while (parentElement.firstChild) {
+      parentElement.removeChild(parentElement.firstChild);
+    }
+    parentElement.appendChild(div);
   }
-
-  // remove all children and set new content
-  while (parentElement.firstChild) {
-    parentElement.removeChild(parentElement.firstChild);
-  }
-  parentElement.appendChild(div);
 }
 
 // Communicate with background script to fetch cookies (only background script
 // is allowed to do this)
+// Credentials are already validated in the background.js
+// This returns `null` if no credentials are found
 async function retrieveSpotifyCookies() {
-  // sends a message to the background.js and retrieve cookies
-  const message = await RUNTIME.runtime.sendMessage({ type: "spotifycookies" });
-  // Credentials are returned in the response (and already validated)
-  // This returns `null` if no credentials are found
-  return message.response;
+  try {
+    const message = await RUNTIME.runtime.sendMessage({
+      type: "spotifycookies",
+    });
+    return message.response;
+  } catch (error) {
+    // No valid credentials found yet (which is not an error)
+    return null;
+  }
 }
 
 // Check if current website is the Open Podcast website where we want to show the
 // credentials. This is only used on openpodcast.dev
 function isOnOpenPodcastDevWebsite() {
-  const res =
+  return (
     /^(https?:\/\/)?(www\.)?(openpodcast\.dev|localhost)/.test(
       window.location.href
-    ) && document.getElementById("openpodcast-plugin") !== null;
-  return res;
+    ) && document.getElementById("openpodcast-plugin") !== null
+  );
 }
 
 // Function to initiate the loop
 function checkForCredentials() {
-  checkLoopTimer = setInterval(async () => {
-    if (isOnOpenPodcastDevWebsite()) {
-      const spotifyCredentials = await retrieveSpotifyCookies();
-
-      if (spotifyCredentials) {
-        showCredentialsOnWebsite(spotifyCredentials);
-
-        // Clear the timer interval since the credentials have been retrieved
-        // This will stop the loop
-        clearInterval(checkLoopTimer);
+  setInterval(async () => {
+    if (isOnOpenPodcastDevWebsite() && !checkInProgress) {
+      checkInProgress = true;
+      try {
+        const spotifyCredentials = await retrieveSpotifyCookies();
+        if (spotifyCredentials) {
+          showCredentialsOnWebsite(spotifyCredentials);
+        }
+      } catch (error) {
+        console.error("Error checking for credentials:", error);
+      } finally {
+        checkInProgress = false;
       }
     }
   }, 1000);

--- a/src/openpodcast.js
+++ b/src/openpodcast.js
@@ -52,11 +52,12 @@ function showCredentialsOnWebsite(credentials) {
   }
 }
 
+// Old flow, which is still used on openpodcast.dev
 // Communicate with background script to fetch cookies (only background script
 // is allowed to do this)
 // Credentials are already validated in the background.js
 // This returns `null` if no credentials are found
-async function retrieveSpotifyCookies() {
+async function retrieveSpotifyCookiesFromBackground() {
   try {
     const message = await RUNTIME.runtime.sendMessage({
       type: "spotifycookies",
@@ -84,7 +85,7 @@ function checkForCredentials() {
     if (isOnOpenPodcastDevWebsite() && !checkInProgress) {
       checkInProgress = true;
       try {
-        const spotifyCredentials = await retrieveSpotifyCookies();
+        const spotifyCredentials = await retrieveSpotifyCookiesFromBackground();
         if (spotifyCredentials) {
           showCredentialsOnWebsite(spotifyCredentials);
         }


### PR DESCRIPTION
- Added support for local development (`localhost` in manifest)
- Added support for message-passing to background worker (a.k.a. "new flow"). This avoid manipulating the DOM and instead the frontend can poll the state of the Spotify credentials.
- Made the code more idiomatic (I hope) and added better error-handling.
- Kept compatibility with openpodcast.dev. We can remove that as a next step after the migration.